### PR TITLE
Make build work on Linux with gcc

### DIFF
--- a/src/clausal.cpp
+++ b/src/clausal.cpp
@@ -318,7 +318,7 @@ static unsigned next_hash_int(unsigned sofar, int val) {
 	size_t osize = var_hash.size();
 	size_t nsize = osize + (1 + (var - osize)/CHUNK_SIZE) * CHUNK_SIZE;
 	var_hash.resize(nsize);
-	const char *ostate = setstate(hash_state);
+	char *ostate = setstate(hash_state);
 	for (unsigned i = osize; i < nsize; i++)
 	    var_hash[i] = random() % hash_modulus;
 	setstate(ostate);

--- a/src/counters.c
+++ b/src/counters.c
@@ -46,7 +46,7 @@ int get_count(counter_t counter) {
 
 }
 
-static bool timer_ok(timer_t timer) {
+static bool timer_ok(cpog_timer_t timer) {
     test_init();
     bool ok = timer >= 0 && timer < TIME_NUM;
     if (!ok)
@@ -54,13 +54,13 @@ static bool timer_ok(timer_t timer) {
     return ok;
 }
 
-void incr_timer(timer_t timer, double secs) {
+void incr_timer(cpog_timer_t timer, double secs) {
     if (!timer_ok(timer))
 	return;
     timers[timer] += secs;
 }
 
-double get_timer(timer_t timer) {
+double get_timer(cpog_timer_t timer) {
     if (!timer_ok(timer))
 	return -1;
     return timers[timer];

--- a/src/counters.h
+++ b/src/counters.h
@@ -41,7 +41,7 @@ typedef enum {
     COUNT_NUM
 } counter_t;
 
-typedef enum { TIME_TOTAL, TIME_SAT, TIME_NUM } timer_t;
+typedef enum { TIME_TOTAL, TIME_SAT, TIME_NUM } cpog_timer_t;
 
 typedef enum { HISTO_PROBLEM, HISTO_PROOF, HISTO_NUM } histogram_t;
 
@@ -58,8 +58,8 @@ void incr_count(counter_t counter);
 void incr_count_by(counter_t counter, int val);
 int get_count(counter_t counter);
 
-void incr_timer(timer_t timer, double secs);
-double get_timer(timer_t timer);
+void incr_timer(cpog_timer_t timer, double secs);
+double get_timer(cpog_timer_t timer);
 
 void incr_histo(histogram_t h, int datum);
 ilist get_histo(histogram_t h);


### PR DESCRIPTION
I hope you're ok with an out-of-the-blue PR, I didn't see a `CONTRIBUTING.md` file.
I was trying to build cpog on Linux and ran into two issues, fixed below:
1. `timer_t` is already defined in `time.h` on Linux and other unices that use a later POSIX version than MacOS, so I've renamed the local type.
2. gcc doesn't like to cast a `const char*` to a `char*` and according to the type of `setstate` that was never a guarantee on its output type anyway; so I changed the type of the local variable to `char*`.